### PR TITLE
docker-compose project uses deprecated links

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - .:/home/node/code
       - /home/node/code/node_modules
-    depends_on:
+    links:
       - db
     environment:
       MONGO_CONNECTION_STRING: mongodb://db:27017

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - .:/home/node/code
       - /home/node/code/node_modules
-    links:
+    depends_on:
       - db
     environment:
       MONGO_CONNECTION_STRING: mongodb://db:27017

--- a/docker-compose/index.js
+++ b/docker-compose/index.js
@@ -1,7 +1,14 @@
-// more-or-less the example code from the hapi-pino repo
 const hapi = require("@hapi/hapi");
+const { MongoClient } = require("mongodb");
+const url = process.env.MONGO_CONNECTION_STRING || "mongodb://localhost:27017";
+const dbName = "dockerApp";
+const collectionName = "count";
 
 async function start() {
+  const client = await MongoClient.connect(url);
+  const db = client.db(dbName);
+  const collection = db.collection(collectionName);
+
   const server = hapi.server({
     host: "0.0.0.0",
     port: process.env.PORT || 3000
@@ -10,8 +17,18 @@ async function start() {
   server.route({
     method: "GET",
     path: "/",
-    handler() {
-      return { success: true };
+    async handler() {
+      const count = await collection.count();
+      return { success: true, count };
+    }
+  });
+
+  server.route({
+    method: "GET",
+    path: "/add",
+    async handler() {
+      const res = await collection.insertOne({});
+      return { inserted: res.insertedCount };
     }
   });
 


### PR DESCRIPTION
Hi,

First of all, I've enjoyed the course greatly and learned a fair bit. Especially the intro with how it's really a collection of low level kernel features that allows for containerisation. Thank you for this! ❤️ 

In the _Docker Compose_ chapter you suggest using `links` to:
1. make sure both of the containers `web` and `db` have network access to one another,
2. and to make sure the `db` container is run before the `web` container.

[`links` reference for version 3](https://docs.docker.com/compose/compose-file/#links) warns it's deprecated.

The networking part is not completely true. In Compose all containers from a single `docker-compose.yml` are connected to a single network and can reach each other by default. Using `links` for this is not necessary. It's in the beginning of https://docs.docker.com/compose/networking/

For the second point — to make sure order of running containers is kept — you can use [`depends_on`](https://docs.docker.com/compose/compose-file/#depends_on). But the flag itself is very simple in its implementation and [comes with a lot of gotchas explained in docs](https://docs.docker.com/compose/startup-order/). In the gist, the container can be already running, but the service it's providing could still be starting and not ready to handle requests.

Oh, and the `index.js` didn't use the mongo service at all, so I've copied over `index.js` from the networking project that connects to mongo.